### PR TITLE
My proposed version for `feature/response-exception`

### DIFF
--- a/src/Exception/TemplateResponseException.php
+++ b/src/Exception/TemplateResponseException.php
@@ -22,6 +22,7 @@ use Contao\TemplateLoader;
 class TemplateResponseException extends ResponseException
 {
     private $template;
+    private $extensions = ['html5'];
 
     /**
      * Constructor
@@ -84,14 +85,20 @@ class TemplateResponseException extends ResponseException
             return false;
         }
 
-        $name = basename($this->template);
+        $extension = pathinfo($this->template, PATHINFO_EXTENSION);
 
-        if (file_exists(TL_ROOT . '/templates/' . $name . '.html5')) {
-            return TL_ROOT . '/templates/' . $name . '.html5';
+        if (!in_array($extension, $this->extensions)) {
+            return false;
         }
 
-        if (file_exists(TL_ROOT . '/' . $this->template . '.html5')) {
-            return TL_ROOT . '/' . $this->template . '.html5';
+        $name = basename($this->template);
+
+        if (file_exists(TL_ROOT . '/templates/' . $name)) {
+            return TL_ROOT . '/templates/' . $name;
+        }
+
+        if (file_exists(TL_ROOT . '/' . $this->template)) {
+            return TL_ROOT . '/' . $this->template;
         }
 
         return false;

--- a/src/Exception/TemplateResponseException.php
+++ b/src/Exception/TemplateResponseException.php
@@ -12,6 +12,8 @@
 
 namespace Contao\ContaoBundle\Exception;
 
+use Contao\TemplateLoader;
+
 /**
  * Creates a response object from a template
  *
@@ -55,37 +57,15 @@ class TemplateResponseException extends ResponseException
      */
     public function getContent()
     {
-        $file = $this->getTemplatePath();
-
-        if ($file === false) {
+        try {
+            $file = TemplateLoader::getPath($this->template, 'html5');
+        } catch (\Exception $e) {
             return $this->getMessage();
         }
 
         ob_start();
-        include TL_ROOT . '/' . $file;
+        include $file;
 
         return ob_get_clean();
-    }
-
-    /**
-     * Search for a custom template and return the path
-     *
-     * @return string|bool The custom template path or false if there is no custom template
-     */
-    protected function getTemplatePath()
-    {
-        if ($this->template == '') {
-            return false;
-        }
-
-        if (file_exists(TL_ROOT . '/templates/' . $this->template . '.html5')) {
-            return 'templates/' . $this->template . '.html5';
-        }
-
-        if (file_exists(TL_ROOT . '/system/modules/core/templates/backend/' . $this->template . '.html5')) {
-            return 'system/modules/core/templates/backend/' . $this->template . '.html5';
-        }
-
-        return false;
     }
 }

--- a/src/Exception/TemplateResponseException.php
+++ b/src/Exception/TemplateResponseException.php
@@ -55,7 +55,7 @@ class TemplateResponseException extends ResponseException
      */
     public function getContent()
     {
-        $file = $this->getTemplateFile();
+        $file = $this->getTemplatePath();
 
         if ($file === false) {
             return $this->getMessage();
@@ -72,7 +72,7 @@ class TemplateResponseException extends ResponseException
      *
      * @return string|bool The custom template path or false if there is no custom template
      */
-    protected function getTemplateFile()
+    protected function getTemplatePath()
     {
         if ($this->template == '') {
             return false;

--- a/src/Exception/TemplateResponseException.php
+++ b/src/Exception/TemplateResponseException.php
@@ -33,7 +33,7 @@ class TemplateResponseException extends ResponseException
      */
     public function __construct($template, $statusCode = 200, array $headers = [], $message = null, $code = 0, \Exception $previous = null)
     {
-        $this->template = $template;
+        $this->template = basename($template);
 
         parent::__construct('', $statusCode, $message, $headers, $code, $previous);
     }
@@ -62,7 +62,7 @@ class TemplateResponseException extends ResponseException
         }
 
         ob_start();
-        include $file;
+        include TL_ROOT . '/' . $file;
 
         return ob_get_clean();
     }
@@ -78,21 +78,12 @@ class TemplateResponseException extends ResponseException
             return false;
         }
 
-        $filename = basename($this->template);
-
-        // Search in root template folder for a custom version
-        if (file_exists(TL_ROOT . '/templates/' . $filename . '.html5')) {
-            return TL_ROOT . '/templates/' . $filename . '.html5';
+        if (file_exists(TL_ROOT . '/templates/' . $this->template . '.html5')) {
+            return 'templates/' . $this->template . '.html5';
         }
 
-        // If template is a relative path inside Contao
-        if (file_exists(TL_ROOT . '/' . $this->template)) {
-            return TL_ROOT . '/' . $this->template;
-        }
-
-        // For Contao core exceptions (previous "die_nicely")
-        if (file_exists(TL_ROOT . '/system/modules/core/templates/backend/' . $filename . '.html5')) {
-            return TL_ROOT . '/system/modules/core/templates/backend/' . $filename . '.html5';
+        if (file_exists(TL_ROOT . '/system/modules/core/templates/backend/' . $this->template . '.html5')) {
+            return 'system/modules/core/templates/backend/' . $this->template . '.html5';
         }
 
         return false;


### PR DESCRIPTION
Here another proposal for `feature/response-exception`, which adds the following:
- Additional security by applying `basename()` to the template name
- Return relative paths in `getTemplateFile()`
- Remove the potentially insecure changes regarding a variable template path
